### PR TITLE
add option to number counter-examples from zero

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -62,6 +62,8 @@ data Settings = Settings
   , timeout   :: Maybe Int
   , produceXml :: Bool
   , printVersion :: Bool
+  -- whether counter-example steps should start at step 0 or 1
+  , zeroBasedCex :: Bool
   }
 
 options :: OptSpec Settings
@@ -152,6 +154,10 @@ options = OptSpec
       , Option [] ["xml"]
         "Produce XML output in the style of Kind 2."
         $ NoArg $ \s -> Right s { produceXml = True }
+
+      , Option [] ["zero-based-cex"]
+        "Numbers the first step of a counter-example 0 rather than 1"
+        $ NoArg $ \s -> Right s { zeroBasedCex = True }
       ]
 
   , progParamDocs = [("FILE", "Lustre files containing model (required, unless --in-dir).")]
@@ -176,6 +182,7 @@ options = OptSpec
     , timeout = Nothing
     , produceXml = False
     , printVersion = False
+    , zeroBasedCex = False
     }
 
 
@@ -415,7 +422,7 @@ checkQuery lgr settings mi nd ts_ast ts (l',q) =
          Just (Invalid r)
           | testMode settings ->
             do sayFail lgr "Invalid" ""
-               let siTr = simpleTrace  mi l' r
+               let siTr = simpleTrace (zeroBasedCex settings) mi l' r
                unless (noTrace settings) $ sayFail lgr "Trace" ('\n' : siTr)
                pure (Invalid ())
 
@@ -429,7 +436,7 @@ checkQuery lgr settings mi nd ts_ast ts (l',q) =
                sayFail lgr "Invalid" ("See " ++ (propDir </> "index.html"))
                saveUI propDir
                let jsTr = declareTrace mi l' r
-               let siTr = simpleTrace  mi l' r
+               let siTr = simpleTrace  (zeroBasedCex settings) mi l' r
                saveOutput (outTraceFile settings l) jsTr
                unless (noTrace settings) $
                  sayFail lgr "Trace" ('\n' : siTr)
@@ -556,4 +563,3 @@ saveOutputTesting lab val =
      putStrLn (replicate (length lab) '=')
      putStrLn ""
      putStrLn val
-

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -152,11 +152,11 @@ options = OptSpec
         $ NoArg $ \s -> Right s { printVersion = True }
 
       , Option [] ["xml"]
-        "Produce XML output in the style of Kind 2."
-        $ NoArg $ \s -> Right s { produceXml = True }
+        "Produce XML output in the style of Kind 2. Implies --zero-based-cex."
+        $ NoArg $ \s -> Right s { produceXml = True, zeroBasedCex = True }
 
       , Option [] ["zero-based-cex"]
-        "Numbers the first step of a counter-example 0 rather than 1"
+        "Numbers the first step of a counter-example 0 rather than 1."
         $ NoArg $ \s -> Right s { zeroBasedCex = True }
       ]
 
@@ -427,7 +427,7 @@ checkQuery lgr settings mi nd ts_ast ts (l',q) =
                pure (Invalid ())
 
           | produceXml settings ->
-            do sayElement lgr (xmlTrace  mi l' r)
+            do sayElement lgr (xmlTrace (zeroBasedCex settings) mi l' r)
                lPutLn lgr
                pure (Invalid ())
 

--- a/src/Report.hs
+++ b/src/Report.hs
@@ -14,8 +14,8 @@ import TransitionSystem(Trace(..))
 
 -- | Print a shorter, text based trace.  We just display the inputs
 -- and outputs for the top node.
-simpleTrace :: ModelInfo -> Label -> LTrace -> String
-simpleTrace mi pn tr =
+simpleTrace :: Bool -> ModelInfo -> Label -> LTrace -> String
+simpleTrace zeroBased mi pn tr =
   Text.unpack (labText pn) ++ ":\n" ++
   (tabulate $ header : zipWith showStep [ 1 :: Integer .. ] (traceSteps tr))
   where
@@ -25,8 +25,9 @@ simpleTrace mi pn tr =
     where
     vs = fst <$> locVars topLoc
 
-  showStep n (_, s) = show n : map sh (vIns vs) ++ ("" : map sh (vOuts vs))
+  showStep n (_, s) = sn : map sh (vIns vs) ++ ("" : map sh (vOuts vs))
     where
+    sn        = show (if zeroBased then n - 1 else n)
     vs        = lookupVars topLoc s
     sh (_,_,mb) = case mb of
                     Nothing -> "?"
@@ -43,7 +44,3 @@ tabulate rows0 = unlines (h : sep : hs)
   colWidths  = map (maximum . map length) (transpose rows)
   padTo n xs = xs ++ replicate (n - length xs) ' '
   shRow xs   = intercalate "|" (zipWith padTo colWidths xs)
-
-
-
-

--- a/src/Report.hs
+++ b/src/Report.hs
@@ -17,7 +17,7 @@ import TransitionSystem(Trace(..))
 simpleTrace :: Bool -> ModelInfo -> Label -> LTrace -> String
 simpleTrace zeroBased mi pn tr =
   Text.unpack (labText pn) ++ ":\n" ++
-  (tabulate $ header : zipWith showStep [ 1 :: Integer .. ] (traceSteps tr))
+  (tabulate $ header : zipWith showStep [ firstStep .. ] (traceSteps tr))
   where
   Just topLoc = locTop mi
 
@@ -25,9 +25,11 @@ simpleTrace zeroBased mi pn tr =
     where
     vs = fst <$> locVars topLoc
 
-  showStep n (_, s) = sn : map sh (vIns vs) ++ ("" : map sh (vOuts vs))
+  firstStep :: Integer
+  firstStep = if zeroBased then 0 else 1
+
+  showStep n (_, s) = show n : map sh (vIns vs) ++ ("" : map sh (vOuts vs))
     where
-    sn        = show (if zeroBased then n - 1 else n)
     vs        = lookupVars topLoc s
     sh (_,_,mb) = case mb of
                     Nothing -> "?"


### PR DESCRIPTION
@atomb 

Here is a proposal implementation of the wanted feature, using a command-line flag named `--zero-based-cex` to alter the numbering scheme.